### PR TITLE
Fix: copy&paste problems Fe instead of Be

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -284,7 +284,7 @@ class ModuleController extends ActionController
                     $runs[] = $importer::doImport($ldapServer);
                 }
                 if ($settings->getAuthenticateBe()) {
-                    $ldapServer->setUserType('fe');
+                    $ldapServer->setUserType('be');
                     $runs[] = $importer::doImport($ldapServer);
                 }
             }
@@ -494,7 +494,7 @@ class ModuleController extends ActionController
             $runs[] = $importer::doDelete('fe', $settings->getHideNotDelete(), $settings->getDeleteNonLdapUsers());
         }
         if ($settings->getAuthenticateBe()) {
-            $runs[] = $importer::doDelete('fe', $settings->getHideNotDelete(), $settings->getDeleteNonLdapUsers());
+            $runs[] = $importer::doDelete('be', $settings->getHideNotDelete(), $settings->getDeleteNonLdapUsers());
         }
 
         $arguments = [

--- a/Classes/Domain/Model/LdapUser/LdapBeUser.php
+++ b/Classes/Domain/Model/LdapUser/LdapBeUser.php
@@ -42,7 +42,7 @@ class LdapBeUser extends LdapEntity
 
     public function __construct()
     {
-        $this->groupObject = new LdapFeGroup();
+        $this->groupObject = new LdapBeGroup();
     }
 
     /**

--- a/Classes/Service/Mapping/LdapTypo3GroupMapper.php
+++ b/Classes/Service/Mapping/LdapTypo3GroupMapper.php
@@ -272,7 +272,7 @@ class LdapTypo3GroupMapper
         string $lastRun = null): array
     {
         if ($userType == 'be') {
-            $groupRules = $ldapServer->getConfiguration()->getFeUserRules()->getGroupRules();
+            $groupRules = $ldapServer->getConfiguration()->getBeUserRules()->getGroupRules();
             $groupRepository = GeneralUtility::makeInstance(BackendUserGroupRepository::class);
             $groupObject = 'NormanSeibert\Ldap\Domain\Model\Typo3User\BackendUserGroup';
         } else {

--- a/Classes/Service/Mapping/LdapTypo3GroupMapper.php
+++ b/Classes/Service/Mapping/LdapTypo3GroupMapper.php
@@ -273,7 +273,7 @@ class LdapTypo3GroupMapper
         string $lastRun = null): array
     {
         if ($userType == 'be') {
-            $groupRules = $ldapServer->getConfiguration()->getFeUserRules()->getGroupRules();
+            $groupRules = $ldapServer->getConfiguration()->getBeUserRules()->getGroupRules();
             $groupRepository = GeneralUtility::makeInstance(BackendUserGroupRepository::class);
             $groupObject = 'NormanSeibert\Ldap\Domain\Model\Typo3User\BackendUserGroup';
         } else {


### PR DESCRIPTION
LdapBeUser was initialized with a LdapFeGroup added to $this->groupObject. It should have been LdapBeGroup.
In LdapTypo3GroupMapper frontend group rules are loaded for backend user.