### PR TITLE
 fix: PHP 8.3 deprecates second parameter of ldap_connect

### DIFF
--- a/Classes/Service/LdapHandler.php
+++ b/Classes/Service/LdapHandler.php
@@ -430,17 +430,20 @@ class LdapHandler
     private function ldapConnect(LdapServer $server)
     {
         $connect = false;
-        $uid = $server->getUid();
-        $host = $server->getConfiguration()->getHost();
-        $port = $server->getConfiguration()->getPort();
-        if (0 == strlen($port)) {
+        $uid = (int)$server->getUid();
+        $host = $server->getConfiguration()->getHost() ?? '';
+        $port = (int)$server->getConfiguration()->getPort();
+        if (0 === strlen($port)) {
             $port = 389;
         }
-        $version = $server->getConfiguration()->getVersion();
-        $forceTLS = $server->getConfiguration()->getForceTLS();
+        $version = (int)$server->getConfiguration()->getVersion();
+        $forceTLS = (int)$server->getConfiguration()->getForceTLS();
+
+        $ldapProtocol = $port == 636 || $forceTLS ? 'ldaps' : 'ldap';
+        $ldapUri = $ldapProtocol . '://' . $host . ':' . $port;
 
         try {
-            $connect = ldap_connect($host, $port);
+            $connect = ldap_connect($ldapUri);
         } catch (Exception $e) {
             $msg = 'ldap_connect(' . $uid . ', ' . $host . ':' . $port . '): Could not connect to LDAP server.';
             $this->logger->error($msg);

--- a/Classes/Service/LdapHandler.php
+++ b/Classes/Service/LdapHandler.php
@@ -439,7 +439,7 @@ class LdapHandler
         $version = (int)$server->getConfiguration()->getVersion();
         $forceTLS = (int)$server->getConfiguration()->getForceTLS();
 
-        $ldapProtocol = $port == 636 || $forceTLS ? 'ldaps' : 'ldap';
+        $ldapProtocol = $port === 636 || $forceTLS ? 'ldaps' : 'ldap';
         $ldapUri = $ldapProtocol . '://' . $host . ':' . $port;
 
         try {


### PR DESCRIPTION
PHP 8.3 deprecates second parameter of ldap_connect signature see:
https://www.php.net/manual/en/function.ldap-connect.php

That leaves only uri connection string.

Also added casts for expected types.